### PR TITLE
Fix workflow error propagation

### DIFF
--- a/src/main/kotlin/io/liquidsoftware/workflow/WorkflowDsl.kt
+++ b/src/main/kotlin/io/liquidsoftware/workflow/WorkflowDsl.kt
@@ -192,12 +192,11 @@ internal class SequentialWorkflowChainBuilder<UCC : UseCaseCommand, I : Workflow
         var currentResult: Either<WorkflowError, WorkflowResult> = result.right()
         for (workflow in workflows) {
           if (currentResult.isRight()) {
-            val result = (currentResult as Either.Right).value
-            val nextResult = workflow.step(result, result.context, command)
-            currentResult = nextResult.fold(
-              { currentResult },
-              { workflowResult -> workflowResult.combine(result).right() }
-            )
+            val prevResult = (currentResult as Either.Right).value
+            val nextResult = workflow.step(prevResult, prevResult.context, command)
+            currentResult = nextResult.map { workflowResult ->
+              workflowResult.combine(prevResult)
+            }
           } else {
             break
           }


### PR DESCRIPTION
## Summary
- ensure sequential workflow chains propagate errors
- test failure when a workflow in the middle of a chain fails

## Testing
- `./gradlew test --tests io.liquidsoftware.workflow.WorkflowChainTest.should\ propagate\ failure\ from\ intermediate\ workflow -q` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6840821b2930832d8c2e07f588ec8e46