### PR TITLE
Use property references for workflow property mapping

### DIFF
--- a/src/test/kotlin/io/liquidsoftware/workflow/AutoMappingExampleTest.kt
+++ b/src/test/kotlin/io/liquidsoftware/workflow/AutoMappingExampleTest.kt
@@ -19,8 +19,8 @@ class AutoMappingExampleTest {
     val useCase = useCase<RegisterCustomerCommand> {
       // Auto-mapping for first workflow with property map
       first(validateCustomerWorkflow, mapOf(
-        "email" to "email",
-        "name" to "name"
+        ValidateCustomerInput::email to RegisterCustomerCommand::email,
+        ValidateCustomerInput::name to RegisterCustomerCommand::name
       ))
 
       // Auto-mapping - fields match directly with ValidatedCustomerEvent
@@ -46,14 +46,14 @@ class AutoMappingExampleTest {
     val useCase = useCase<RegisterCustomerCommand> {
       // Auto-mapping for first workflow with builder pattern
       first(validateCustomerWorkflow) {
-        "email" from "email"
-        "name" from "name"
+        ValidateCustomerInput::email from RegisterCustomerCommand::email
+        ValidateCustomerInput::name from RegisterCustomerCommand::name
       }
 
       // Auto-mapping with property name mapping
       this.then(sendWelcomeEmailWorkflow, mapOf(
-        "recipientEmail" to "email",
-        "recipientName" to "name"
+        SendWelcomeEmailInput::recipientEmail to RegisterCustomerCommand::email,
+        SendWelcomeEmailInput::recipientName to RegisterCustomerCommand::name
       ))
     }
 
@@ -77,8 +77,8 @@ class AutoMappingExampleTest {
     val useCase = useCase<RegisterCustomerCommand> {
       // Auto-mapping for first workflow with property map
       first(validateCustomerWorkflow, mapOf(
-        "email" to "email",
-        "name" to "name"
+        ValidateCustomerInput::email to RegisterCustomerCommand::email,
+        ValidateCustomerInput::name to RegisterCustomerCommand::name
       ))
 
       // Auto-mapping - fields match directly with ValidatedCustomerEvent
@@ -86,15 +86,15 @@ class AutoMappingExampleTest {
 
       // Auto-mapping with property name mapping
       this.then(sendWelcomeEmailWorkflow, mapOf(
-        "recipientEmail" to "email",
-        "recipientName" to "name"
+        SendWelcomeEmailInput::recipientEmail to RegisterCustomerCommand::email,
+        SendWelcomeEmailInput::recipientName to RegisterCustomerCommand::name
       ))
 
       // Auto-mapping using builder pattern
       then(storeCustomerWorkflow) {
-        "customerEmail" from "email"
-        "customerName" from "name"
-        "customerId" from "id"
+        StoreCustomerInput::customerEmail from ValidatedCustomerEvent::email
+        StoreCustomerInput::customerName from ValidatedCustomerEvent::name
+        StoreCustomerInput::customerId from ValidatedCustomerEvent::id
       }
     }
 

--- a/src/test/kotlin/io/liquidsoftware/workflow/OrderProcessingWorkflow.kt
+++ b/src/test/kotlin/io/liquidsoftware/workflow/OrderProcessingWorkflow.kt
@@ -41,8 +41,8 @@ fun main() {
     parallel {
       then(CheckInventoryWorkflow("check-inventory"))
       then(ProcessPaymentWorkflow("process-payment")) {
-        "orderId" from "orderId"  // This would be automatic, but including for clarity
-        "amount" from "totalAmount" // Map from command's totalAmount to amount in ProcessPaymentCommand
+        ProcessPaymentCommand::orderId from ProcessOrderCommand::orderId  // This would be automatic, but including for clarity
+        ProcessPaymentCommand::amount from ProcessOrderCommand::totalAmount // Map from command's totalAmount to amount in ProcessPaymentCommand
       }
     }
 
@@ -57,7 +57,7 @@ fun main() {
       }
     ) {
       // Map from different event fields to the shipment command fields
-      "items" from "availableItems" // from InventoryVerifiedEvent
+      PrepareShipmentCommand::items from InventoryVerifiedEvent::availableItems // from InventoryVerifiedEvent
     }
   }
 

--- a/src/test/kotlin/io/liquidsoftware/workflow/WorkflowChainTest.kt
+++ b/src/test/kotlin/io/liquidsoftware/workflow/WorkflowChainTest.kt
@@ -18,7 +18,7 @@ class WorkflowChainTest {
 
     val useCase: UseCase<TestUseCaseCommand> = useCase {
       first(workflow = initialWorkflow)
-      this.then(nextWorkflow, mapOf("id" to "id"))
+      this.then(nextWorkflow, mapOf(TestCommand::id to TestEvent::id))
       build()
     }
 
@@ -42,7 +42,7 @@ class WorkflowChainTest {
 
     val useCase: UseCase<TestUseCaseCommand> = useCase {
       first(workflow = initialWorkflow)
-      this.then(nextWorkflow, mapOf("id" to "id"))
+      this.then(nextWorkflow, mapOf(TestCommand::id to TestEvent::id))
       build()
     }
 
@@ -63,7 +63,7 @@ class WorkflowChainTest {
 
     val useCase: UseCase<io.liquidsoftware.workflow.TestUseCaseCommand> = useCase {
       first(workflow = initialWorkflow)
-      this.then(nextWorkflow, mapOf("id" to "id"))
+      this.then(nextWorkflow, mapOf(TestCommand::id to TestEvent::id))
       build()
     }
 
@@ -164,8 +164,8 @@ class WorkflowChainTest {
 
     val useCase: UseCase<TestUseCaseCommand> = useCase {
       first(workflow = initialWorkflow)
-      this.then(secondWorkflow, mapOf("id" to "id"))
-      this.then(thirdWorkflow, mapOf("id" to "id"))
+      this.then(secondWorkflow, mapOf(TestCommand::id to TestEvent::id))
+      this.then(thirdWorkflow, mapOf(TestCommand::id to TestEvent::id))
       build()
     }
 
@@ -185,7 +185,7 @@ class WorkflowChainTest {
 
     val useCase: UseCase<TestUseCaseCommand> = useCase {
       first(workflow = initialWorkflow)
-      this.then(nextWorkflow, mapOf("id" to "id"))
+      this.then(nextWorkflow, mapOf(TestCommand::id to TestEvent::id))
       build()
     }
 
@@ -207,7 +207,7 @@ class WorkflowChainTest {
 
     val useCase: UseCase<TestUseCaseCommand> = useCase {
       first(workflow = initialWorkflow)
-      this.then(nextWorkflow, mapOf("id" to "id"))
+      this.then(nextWorkflow, mapOf(TestCommand::id to TestEvent::id))
       build()
     }
 
@@ -293,8 +293,8 @@ class WorkflowChainTest {
         this.then(secondWorkflow)
         this.then(thirdWorkflow)
       }
-      this.then(fourthWorkflow, mapOf("id" to "id"))
-      this.then(fifthWorkflow, mapOf("id" to "id"))
+      this.then(fourthWorkflow, mapOf(TestCommand::id to TestEvent::id))
+      this.then(fifthWorkflow, mapOf(TestCommand::id to TestEvent::id))
       build()
     }
 
@@ -321,8 +321,8 @@ class WorkflowChainTest {
 
     val useCase: UseCase<TestUseCaseCommand> = useCase {
       first(workflow = workflowA)
-      this.then(workflowB, mapOf("id" to "id"))
-      this.then(workflowC, mapOf("id" to "id"))
+      this.then(workflowB, mapOf(TestCommand::id to TestEvent::id))
+      this.then(workflowC, mapOf(TestCommand::id to TestEvent::id))
       build()
     }
 
@@ -391,7 +391,7 @@ class WorkflowChainTest {
         this.then(secondWorkflow)
         this.then(thirdWorkflow)
       }
-      this.then(fourthWorkflow, mapOf("id" to "id"))
+      this.then(fourthWorkflow, mapOf(TestCommand::id to TestEvent::id))
       build()
     }
 

--- a/src/test/kotlin/io/liquidsoftware/workflow/WorkflowUtilsTest.kt
+++ b/src/test/kotlin/io/liquidsoftware/workflow/WorkflowUtilsTest.kt
@@ -78,7 +78,7 @@ class WorkflowUtilsTest {
         // Given
         val command = TestCommand(UUID.randomUUID(), "Test Name")
         val result = WorkflowResult()
-        val propertyMap = mapOf("id" to "id", "name" to "name")
+        val propertyMap = mapOf(TestWorkflowInput::id to TestCommand::id, TestWorkflowInput::name to TestCommand::name)
 
         // When
         val input = WorkflowUtils.autoMapInput(result, command, propertyMap, TestWorkflowInput::class)
@@ -94,7 +94,7 @@ class WorkflowUtilsTest {
         // Given
         val command = TestCommand(UUID.randomUUID(), "Test Name")
         val result = WorkflowResult()
-        val propertyMap = mapOf("id" to "id", "name" to "name")
+        val propertyMap = mapOf(TestWorkflowInput::id to TestCommand::id, TestWorkflowInput::name to TestCommand::name)
 
         // When
         val input = WorkflowUtils.autoMapInput(result, command, propertyMap, TestWorkflowInput::class)


### PR DESCRIPTION
## Summary
- refactor PropertyMappingBuilder to keep KProperty references
- allow mapping with property reference syntax and auto-map inputs from those references
- update tests and DSL usage to rely on property references

## Testing
- `./gradlew assemble`
- `./gradlew test` *(fails: Could not resolve org.jetbrains.kotlin:kotlin-test:2.1.20)*

------
https://chatgpt.com/codex/tasks/task_e_6895f60cf378832db5facd2243302c9e